### PR TITLE
Add netclusive to hosting providers

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -130,6 +130,16 @@
     "note": ""
   },
   {
+    "name": "netclusive",
+    "link": "https://netclusive.de/",
+    "category": "full",
+    "tutorial": "https://www.netclusive.de/faq/content/36/430/de/kann-ich-meine-webseite-ssl-verschluesseln.html",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2020.10.01",
+    "note": "The website is in german. Old plans of shared web hosting with confixx panel have full HTTPS support. New plans of shared web hosting with Plesk panel also have full HTTPS support."
+  },
+  {
     "name": "Netlify",
     "link": "https://www.netlify.com/",
     "category": "full",


### PR DESCRIPTION
Improved pull request based on information from previous PR #654
Plesk now requests a certificate while the account is created. Exception handling (f. exp. existing domains not already transferred) is described in the tutorial link in german.